### PR TITLE
Fixed the timezone issue

### DIFF
--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -113,11 +113,9 @@
      * @see - <http://docs.python.org/library/datetime.html#datetime.date.fromordinal>
      */
     fromOrdinal: function (ordinal) {
-      var millisecsFromBase = ordinal * dateutil.ONE_DAY
-      return new Date(dateutil.ORDINAL_BASE.getTime() -
-        dateutil.tzOffset(dateutil.ORDINAL_BASE) +
-        millisecsFromBase +
-        dateutil.tzOffset(new Date(millisecsFromBase)))
+      var date = new Date(dateutil.ORDINAL_BASE.getTime())
+      date.setDate(date.getDate() + ordinal)
+      return date
     },
 
     /**


### PR DESCRIPTION
When setting the time zone to Syria, "fromOrdinal" returns the result of the day before the expected value.
Because in[ Syria the time zone was changed from LMT to EET on January 1, 1920](https://www.timeanddate.com/time/change/syria?year=1919).
By using `Date#setDate`, the issue seems to be fixed.